### PR TITLE
Fix blending reset when starting animation groups

### DIFF
--- a/src/characterController.js
+++ b/src/characterController.js
@@ -552,8 +552,8 @@ class CharacterController {
   async playAnimationGroup(animationGroup) {
     return new Promise((resolve, reject) => {
       try {
-        // Stop all animations and reset the character
-        this.stopAllAnimations();
+        // Stop all animations but keep existing blending settings
+        this.stopAllAnimations(false);
         
         // Stop any currently playing animation
         if (this.currentAnimationGroup) {
@@ -607,12 +607,14 @@ class CharacterController {
     return rootMesh;
   }
   
-  // Stop all animations and reset character to default pose
-  stopAllAnimations() {
+  // Stop all animations. Optionally reset groups to their initial state
+  stopAllAnimations(reset = true) {
     // Stop all animation groups in the scene
     this.scene.animationGroups.forEach(group => {
       group.stop();
-      group.reset();
+      if (reset) {
+        group.reset();
+      }
     });
     
     // Reset all morph targets to 0
@@ -623,7 +625,7 @@ class CharacterController {
       }
     });
     
-    console.log("Stopped all animations and reset morph targets");
+    console.log(`Stopped all animations${reset ? " and reset morph targets" : ""}`);
   }
 
   getAnimationGroup(signName) {


### PR DESCRIPTION
## Summary
- ensure playing new animation groups doesn't reset the blending speed by default
- allow `stopAllAnimations` to stop without resetting

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b5fcc588320975e149d5dc8a77b